### PR TITLE
missing_classes

### DIFF
--- a/src/Traits/ListsResult.php
+++ b/src/Traits/ListsResult.php
@@ -2,8 +2,12 @@
 
 namespace AhmadAldali\FilterLists\Traits;
 
+use AhmadAldali\FilterLists\Template\Filter\FilterListTemplate;
+use AhmadAldali\FilterLists\Template\Filter\FilterListTemplateWithWhereBetween;
+
 trait ListsResult
 {
+
     /**
      * @param $model
      * @param $request


### PR DESCRIPTION
1- call FilterListTemplate in ListResults correctly.
2- call FilterListTemplateWithWhereBetween in ListResults correctly.